### PR TITLE
chore(deps): replace umi-test with rc-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bakpublishOnly": "npm run compile && np --yolo --no-publish",
     "prepublishOnly": "npm run compile",
     "lint": "eslint src/ docs/examples/ --ext .tsx,.ts,.jsx,.js",
-    "test": "umi-test",
+    "test": "rc-test",
     "coverage": "rc-test --coverage",
     "now-build": "npm run build"
   },
@@ -63,8 +63,7 @@
     "react-dom": "^18.0.0",
     "regenerator-runtime": "^0.14.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.1.6",
-    "umi-test": "^1.9.7"
+    "typescript": "^5.1.6"
   },
   "dependencies": {
     "@babel/runtime": "^7.24.7",

--- a/src/QRCodeSVG.tsx
+++ b/src/QRCodeSVG.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { useQRCode } from './hooks/useQRCode';
 import type { QRPropsSVG } from './interface';
 import {
   DEFAULT_BACKGROUND_COLOR,
   DEFAULT_FRONT_COLOR,
+  DEFAULT_NEED_MARGIN,
   DEFAULT_LEVEL,
   DEFAULT_MINVERSION,
-  DEFAULT_NEED_MARGIN,
   DEFAULT_SIZE,
   excavateModules,
   generatePath,
 } from './utils';
+import { useQRCode } from './hooks/useQRCode';
 
 const QRCodeSVG = React.forwardRef<SVGSVGElement, QRPropsSVG>(
   function QRCodeSVG(props, forwardedRef) {
@@ -73,7 +73,6 @@ const QRCodeSVG = React.forwardRef<SVGSVGElement, QRPropsSVG>(
         viewBox={`0 0 ${numCells} ${numCells}`}
         ref={forwardedRef}
         role="img"
-        aria-label="QR Code"
         {...otherProps}
       >
         {!!title && <title>{title}</title>}

--- a/src/QRCodeSVG.tsx
+++ b/src/QRCodeSVG.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
+import { useQRCode } from './hooks/useQRCode';
 import type { QRPropsSVG } from './interface';
 import {
   DEFAULT_BACKGROUND_COLOR,
   DEFAULT_FRONT_COLOR,
-  DEFAULT_NEED_MARGIN,
   DEFAULT_LEVEL,
   DEFAULT_MINVERSION,
+  DEFAULT_NEED_MARGIN,
   DEFAULT_SIZE,
   excavateModules,
   generatePath,
 } from './utils';
-import { useQRCode } from './hooks/useQRCode';
 
 const QRCodeSVG = React.forwardRef<SVGSVGElement, QRPropsSVG>(
   function QRCodeSVG(props, forwardedRef) {
@@ -73,6 +73,7 @@ const QRCodeSVG = React.forwardRef<SVGSVGElement, QRPropsSVG>(
         viewBox={`0 0 ${numCells} ${numCells}`}
         ref={forwardedRef}
         role="img"
+        aria-label="QR Code"
         {...otherProps}
       >
         {!!title && <title>{title}</title>}


### PR DESCRIPTION
🤔 This is a …

 - [x] ⭐️ Feature enhancement

**💡 Background and Solution**

Background: In the qr-code component, the SVG rendering mode lacked accessible labeling, which impacted screen reader compatibility and overall accessibility (a11y) support.

Solution: Added an aria-label attribute to the SVG rendering mode, providing a descriptive label that enhances accessibility and allows assistive technologies to better interpret the QR code content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在 `QRCodeSVG` 组件中添加了可访问性增强，增加了 `aria-label="QR Code"` 属性。

- **变更**
  - 更新了测试脚本，从 `"test": "umi-test"` 更改为 `"test": "rc-test"`，并移除了 `umi-test` 依赖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->