### PR TITLE
chore(deps-dev): bump @types/jest from 29 to 30

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^16.0.0",
     "@types/classnames": "^2.2.10",
-    "@types/jest": "^29.5.2",
+    "@types/jest": "^30.0.0",
     "@types/node": "^22.5.1",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
     "coverage": "rc-test --coverage",
     "now-build": "npm run build"
   },
+  "dependencies": {
+    "@babel/runtime": "^7.24.7",
+    "classnames": "^2.3.2"
+  },
   "devDependencies": {
     "@ant-design/tools": "^18.0.2",
     "@rc-component/father-plugin": "^1.0.0",
@@ -63,10 +67,6 @@
     "regenerator-runtime": "^0.14.0",
     "ts-jest": "^29.1.4",
     "typescript": "^5.1.6"
-  },
-  "dependencies": {
-    "@babel/runtime": "^7.24.7",
-    "classnames": "^2.3.2"
   },
   "peerDependencies": {
     "react": ">=16.9.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 杂务
  - 升级开发依赖 @types/jest 至 ^30.0.0，提升与最新测试环境的类型兼容性与编辑器提示质量。该更新不影响运行时或产品功能，无用户可见改动，仅改善本地开发与测试的稳定性与一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->