### PR TITLE
chore: use rc father plugin

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -1,9 +1,5 @@
 import { defineConfig } from 'father';
 
 export default defineConfig({
-  platform: 'browser',
-  cjs: { output: 'lib' },
-  esm: {
-    output: 'es',
-  },
+  plugins: ['@rc-component/father-plugin'],
 });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@ant-design/tools": "^18.0.2",
-    "@rc-component/father-plugin": "^1.0.0",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^16.0.0",
@@ -55,7 +55,7 @@
     "@umijs/fabric": "^4.0.1",
     "dumi": "^2.1.0",
     "eslint": "^8.51.0",
-    "father": "^4.0.0",
+    "father": "^4.4.4",
     "jest-canvas-mock": "^2.5.2",
     "less": "^4.2.0",
     "rc-test": "^7.0.13",


### PR DESCRIPTION
## 调整内容

- 在 `.fatherrc.js` 中接入 `@rc-component/father-plugin`，交给 father-plugin 统一处理 rc 包构建配置和深路径导入检查。
- 升级 `@rc-component/father-plugin` 到 `^2.2.0`。
- 将 `father` 升级到 `^4.4.4`，否则当前 `father@4.0.0` 不识别 `plugins` 配置。

## 验证

- `npm run compile`
- `npm run lint`
- `npm test -- --runInBand`