### PR TITLE
fix: restore browser targets

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -2,4 +2,7 @@ import { defineConfig } from 'father';
 
 export default defineConfig({
   plugins: ['@rc-component/father-plugin'],
+  targets: {
+    ie: 11,
+  },
 });


### PR DESCRIPTION
## Summary
- Restore the browser compile target to the previous Father default while keeping `@rc-component/father-plugin` enabled.
- Prevent private class fields from leaking into the published `es` and `lib` output.

## Root Cause
`@rc-component/father-plugin@2.2.0` defaults `targets` to `{ chrome: 85 }`, which is newer than the previous Father browser default. As a result, the published qrcode output kept `static #_` private fields in `qrcodegen.js`, and older webpack parsers failed with `Unexpected character #`.

## Verification
- `npm run compile`
- `acorn@6` parses `es/libs/qrcodegen.js` and `lib/libs/qrcodegen.js` after the fix
- `npm test -- --runInBand`

Fixes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 增加了对Internet Explorer 11的浏览器支持

<!-- end of auto-generated comment: release notes by coderabbit.ai -->